### PR TITLE
README.md 内の typo を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform module which creates AWS SSO assignments on AWS.
 ## Usage
 ```hcl
 module "account_assignments" {
-  source = "speee/sso_assignments/aws"
+  source = "speee/sso-assignments/aws"
 
   instance_arn      = "arn:aws:sso:::instance/ssoins-9999999999999999"
   identity_store_id = "d-9999999999"


### PR DESCRIPTION
## What
README.md 内の source に typo があったため、こちらをそのままコピペするとモジュールを利用できない状態でした。

```
│ Error: Module not found
│ 
│ Module "prod_assignments" (from assignment.tf:1) cannot be found in the module registry at registry.terraform.io.
```

当該箇所を修正しております。

OSS へ PR するのが初めてであるため作法などに誤りがあるかもしれません。
よろしくお願いいたします。
