### PR TITLE
⚠️⚠️⚠️BREAKING⚠️⚠️⚠️: Change state objects to IDs as group names and user names may change

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ locals {
   group_assignments = merge([
     for account, v in var.assignments : merge([
       for group_name, permission_sets in contains(keys(v), "groups") ? v.groups : {} : {
-        for permission_set_name in permission_sets : "${account}.${group_name}.${permission_set_name}" => {
+        for permission_set_name in permission_sets : "${account}.${data.aws_identitystore_group.groups[group_name].id}.${permission_set_name}" => {
           account             = account
           group_name          = group_name
           permission_set_name = permission_set_name
@@ -38,7 +38,7 @@ locals {
   user_assignments = merge([
     for account, v in var.assignments : merge([
       for user_name, permission_sets in contains(keys(v), "users") ? v.users : {} : {
-        for permission_set_name in permission_sets : "${account}.${user_name}.${permission_set_name}" => {
+        for permission_set_name in permission_sets : "${account}.${data.aws_identitystore_user.users[user_name].id}.${permission_set_name}" => {
           account             = account
           user_name           = user_name
           permission_set_name = permission_set_name


### PR DESCRIPTION
## What
**This is a destructive change.**

Stop using group names and user names as the key names of state objects.
The key names should use the group ID and user ID.

I will release this as 2.0.0 after testing it internally.

If you cannot accept this change, you should fix the version as follows.

```
module "foo_asisignments" {
  source  = "speee/sso-assignment/aws"
  version = "1.0.0"

```

## Why
Group names and user names are attributes that can change.
In our organization, we had to generate a large number of differences every time there was an organisational change, and then execute a large number of terraform mv commands each time.
This was a huge pain for me.

## How
Use group ID and user ID as the key names of objects.

## Ref
