### PR TITLE
Replace deprecated filters with alternate_identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ module "account_assignments" {
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
+| Name | Version   |
+|------|-----------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.24.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.24.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.40.0  |
 
 ## Modules
 

--- a/examples/all-in-one/version.tf
+++ b/examples/all-in-one/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=3.24.0"
+      version = ">=4.40.0"
     }
   }
 }

--- a/examples/module-per-organizations-unit/version.tf
+++ b/examples/module-per-organizations-unit/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=3.24.0"
+      version = ">=4.40.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -53,9 +53,11 @@ data "aws_identitystore_group" "groups" {
 
   identity_store_id = var.identity_store_id
 
-  filter {
-    attribute_path  = "DisplayName"
-    attribute_value = each.value
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = each.value
+    }
   }
 }
 
@@ -64,9 +66,11 @@ data "aws_identitystore_user" "users" {
 
   identity_store_id = var.identity_store_id
 
-  filter {
-    attribute_path  = "UserName"
-    attribute_value = each.value
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = each.value
+    }
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.24.0"
+      version = ">= 4.40.0"
     }
   }
 }


### PR DESCRIPTION
## What
Close #10 

## Why
`filter` is deprecated.
`filter` will not work with terraform-provider-aws v6.
On the other hand, alternate_identifier was implemented in v4.40.0. Older providers cannot use alternate_identifier.

## How
Use alternate_identifier

## Ref
https://github.com/hashicorp/terraform-provider-aws/blob/release/4.x/CHANGELOG.md#4400-november-17-2022